### PR TITLE
Implement adding associations for a deal

### DIFF
--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -11,6 +11,7 @@ from hubspot3.utils import (
     prettify
 )
 
+import urllib.parse
 
 DEALS_API_VERSION = '1'
 
@@ -41,6 +42,15 @@ class DealsClient(BaseClient):
         data = data or {}
         return self._call('deal/{}'.format(key), data=data,
                           method='PUT', **options)
+
+    def associate(self, deal_id, object_type, object_ids, **options):
+        # Encoding the query string here since HubSpot is expecting the "id" parameter to be
+        # repeated for each object ID, which is not a standard practice and won't work otherwise.
+        object_ids = [('id', object_id) for object_id in object_ids]
+        query = urllib.parse.urlencode(object_ids)
+
+        return self._call('deal/{}/associations/{}'.format(deal_id, object_type), method='PUT',
+                          query=query, **options)
 
     def get_all(self, limit=None, offset=0, **options):
         finished = False


### PR DESCRIPTION
Implemented a method for adding deal associations via the [deal associations endpoint](https://developers.hubspot.com/docs/methods/deals/associate_deal).

Having to encode query params here feels a little hacky, but I had to do that since HubSpot is expecting us to repeat the `id` parameter for each object ID, which is kind of non-standard and won't work with the `params` dictionary in `self._call()`.