### PR TITLE
Fix bug where wrong offset is used

### DIFF
--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -86,6 +86,6 @@ class DealsClient(BaseClient):
                 for deal in batch['deals'] if not deal['isDeleted']
             ])
             finished = not batch['hasMore']
-            offset += batch['offset']
+            offset = batch['offset']
 
         return output


### PR DESCRIPTION
So after wasting time, you guys have a bug.
Offset is a long number returend for each page, [as stated in the docs](https://integrate.hubspot.com/t/deals-api-how-to-get-all-deals-in-a-particular-sales-stage/441):


> Used to page through the results. If there are more records in your portal than the limit= parameter, you will need to use the offset returned in the first request to get the next set of results.

"to **use the offset returned** in the first request". Its not added, its a new offset.