### PR TITLE
Add HubSpot's error message on top of HubspotError string representation

### DIFF
--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -24,6 +24,8 @@ class HubspotError(ValueError):
     """Any problems get thrown as HubspotError exceptions with the relevant info inside"""
 
     as_str_template = """
+{error_message} 
+
 ---- request ----
 {method} {host}{url}, [timeout={timeout}]
 
@@ -75,6 +77,9 @@ class HubspotError(ValueError):
         request_keys = ("method", "host", "url", "data", "headers", "timeout", "body")
         result_attrs = ("status", "reason", "msg", "body", "headers")
         params["error"] = self.err
+        params["error_message"] = "Hubspot Error"
+        if type(self.result.body) is dict:
+            params["error_message"] = self.result.body.get("message", "Hubspot Error")
         for key in request_keys:
             params[key] = self.request.get(key)
         for attr in result_attrs:

--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -24,7 +24,7 @@ class HubspotError(ValueError):
     """Any problems get thrown as HubspotError exceptions with the relevant info inside"""
 
     as_str_template = """
-{error_message} 
+{error_message}
 
 ---- request ----
 {method} {host}{url}, [timeout={timeout}]

--- a/hubspot3/test/test_error.py
+++ b/hubspot3/test/test_error.py
@@ -37,3 +37,22 @@ def test_unicode_error():
 def test_error_with_no_result_or_request():
     exc = HubspotError(None, None, "a silly error")
     ok_("a silly error" in exc)
+
+
+def test_error_string_summary():
+    result = MockResult()
+    result.body = {
+        "status": "error",
+        "message": "Property values were not valid"
+    }
+
+    # Make sure string representation of the error starts with the error
+    # message returned by HubSpot.
+    exc = HubspotError(result=result, request={})
+    exc_str_first_line = str(exc).split("\n", 1)[1]
+    ok_(exc_str_first_line.startswith(result.body["message"]))
+
+    # Test falling back to a default error in case response doesn't contain one.
+    exc = HubspotError(result=MockResult(), request={})
+    exc_str_first_line = str(exc).split("\n", 1)[1]
+    ok_(exc_str_first_line.startswith("Hubspot Error"))


### PR DESCRIPTION
`HubspotError` currently uses the following template for generating its string representation, which contains a lot of useful debugging info:

```
---- request ----
{method} {host}{url}, [timeout={timeout}]

---- body ----
{body}

---- headers ----
{headers}

---- result ----
{result_status}

---- body -----
{result_body}

---- headers -----
{result_headers}

---- reason ----
{result_reason}

---- trigger error ----
{error}
```

However I've noticed that when using error-tracking services like Sentry, the first line of the error message is usually used as the issue title, which in this case is `---- request ----` .   This leads to all of HubSpot errors being merged into one issue, making them pretty hard to track and work with.

I suggest adding an error message returned from HubSpot as the first line of `__str__/__unicode__`, which would solve this problem.

My implementation expects HubSpot's error responses to be returned in the following format (which seems to be the one they're using):
```json
{
  "status": "error",
  "message": "Property values were not valid",
  ...
}
```

Haven't added any tests yet, just want to make sure it makes sense to you first.