### PR TITLE
Fix extraction of the error message returned by HubSpot

### DIFF
--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -1,6 +1,8 @@
 """
 hubspot3 error helpers
 """
+import json
+
 from hubspot3.utils import force_utf8
 
 
@@ -78,8 +80,12 @@ class HubspotError(ValueError):
         result_attrs = ("status", "reason", "msg", "body", "headers")
         params["error"] = self.err
         params["error_message"] = "Hubspot Error"
-        if type(self.result.body) is dict:
-            params["error_message"] = self.result.body.get("message", "Hubspot Error")
+        if self.result.body:
+            try:
+                result_body = json.loads(self.result.body)
+            except ValueError:
+                result_body = {}
+            params["error_message"] = result_body.get("message", "Hubspot Error")
         for key in request_keys:
             params[key] = self.request.get(key)
         for attr in result_attrs:

--- a/hubspot3/test/test_error.py
+++ b/hubspot3/test/test_error.py
@@ -41,16 +41,16 @@ def test_error_with_no_result_or_request():
 
 def test_error_string_summary():
     result = MockResult()
-    result.body = {
+    result.body = '''{
         "status": "error",
         "message": "Property values were not valid"
-    }
+    }'''
 
     # Make sure string representation of the error starts with the error
     # message returned by HubSpot.
     exc = HubspotError(result=result, request={})
     exc_str_first_line = str(exc).split("\n", 1)[1]
-    ok_(exc_str_first_line.startswith(result.body["message"]))
+    ok_(exc_str_first_line.startswith("Property values were not valid"))
 
     # Test falling back to a default error in case response doesn't contain one.
     exc = HubspotError(result=MockResult(), request={})


### PR DESCRIPTION
Following-up on #13.

All of the error strings currently just use the default `Hubspot Error` placeholder, because it turns out that I made a mistake and `result.body` is actually a string, not a `dict`. This is my proposed fix for that.

Not sure if it's okay to parse JSON in the error handler. Let me know what you think.