### PR TITLE
Make default retries 2, fixes #25

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -234,7 +234,7 @@ class BaseClient(object):
         if not _PYTHON25:
             kwargs["timeout"] = opts["timeout"]
 
-        num_retries = opts.get("number_retries", 0)
+        num_retries = opts.get("number_retries", 2)
 
         # Never retry a POST, PUT, or DELETE unless explicitly told to
         if method != "GET" and not opts.get("retry_on_post"):


### PR DESCRIPTION
Hey,
I think this is needed because hubspot is unstable these days. However its "your call" kind of PR.
Take it or leave it :)

For my argument see #25