### PR TITLE
Add a CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ ENV/
 # End of https://www.gitignore.io/api/python
 old/
 test_credentials.json
+
+# IDEs
+.idea
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ and you can use it as a command:
 
 .. code-block:: bash
 
-    hubspot --help
+    hubspot3 --help
 
 See the Sphinx documentation for more details and explanations.
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,23 @@ Passing Params
    deal_data = deals_client.get(deal_id, params=params)
    print(json.dumps(deal_data))
 
+Command-line interface
+^^^^^^^^^^^^^^^^^^^^^^
+
+There is also a command-line tool available. Install the extra requirement for that tool via:
+
+.. code-block:: bash
+
+    pip install hubspot3[cli]
+
+and you can use it as a command:
+
+.. code-block:: bash
+
+    hubspot --help
+
+See the Sphinx documentation for more details and explanations.
+
 Rate Limiting
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ html_theme = "default"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+#html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/hubspot3/command_line.rst
+++ b/docs/hubspot3/command_line.rst
@@ -1,0 +1,158 @@
+.. command_line:
+
+Command-line interface
+======================
+
+The hubspot3 client comes with an optional command-line interface that makes it easy to use the client's features
+without necessarily importing it within a Python project.
+
+Installation
+------------
+
+To use the command-line interface you will have to install an additional Python requirement:
+
+.. code-block:: bash
+
+    pip install hubspot3[cli]
+
+Usage
+-----
+
+After the installation you can use the client with the ``hubspot3`` command, e.g. to display the help:
+
+.. code-block:: bash
+
+    hubspot3 --help
+
+This will display all arguments for the general usage of the command-line client, like the API key (or a config file,
+see below). Please take a look into the constructor of the ``hubspot3.Hubspot3`` class for the list of provided
+arguments.
+
+By just calling ``hubspot3`` you will get a list of all featured APIs that are available, e.g.:
+
+.. code-block:: bash
+
+    huspot3
+
+    Usage:       hubspot3 -
+                 hubspot3 - blog
+                 hubspot3 - blog-comments
+                 hubspot3 - broadcast
+    [...]
+
+By attaching the API name you can access the specific API endpoints:
+
+.. code-block:: bash
+
+    hubspot3 deals
+
+    Usage:       hubspot3 deals
+                 hubspot3 deals associate
+                 hubspot3 deals create
+                 hubspot3 deals get
+    [...]
+
+Each API method has it's own documentation and the help can be displayed like this:
+
+.. code-block:: bash
+
+    hubspot3 deals get -- --help
+
+    [...]
+    Docstring:   Supported ARGS/KWARGS are:
+    DEAL_ID [--OPTIONS ...]
+    --deal-id DEAL_ID [--OPTIONS ...]
+    [...]
+
+This will display the methods parameter list and how to pass them to the specific API endpoint, in this case you can
+get the deal information for a specific deal with:
+
+.. code-block:: bash
+
+    hubspot3 --api-key xxxxxxxxx-xxxx-xxx-xxxx-xxxxx deals get --deal-id 100
+
+.. note::
+
+    You will notice the leading ``--`` in front of the ``--help`` parameter. Hubspot3 uses the ``python-fire`` library
+    to generate a dynamic command-line interface for all API clients. If you don't add the ``--`` the help command will
+    be passed as an argument API method instead of invoking Fire's help output, so we have to set it. Generally
+    speaking, the arguments for the API method call need to be separated from general CLI arguments using ``--``.
+
+Configuration file
+^^^^^^^^^^^^^^^^^^
+
+Instead of providing the API key (``--api-key``) or other settings (like ``--client-id`` or ``--timeout``) as
+parameters you can also create a local JSON file, that contains all the settings you want to pass to the client:
+
+.. code-block:: json
+
+    {
+        "api_key": "xxxxxxxxx-xxxx-xxx-xxxx-xxxxx",
+        "timeout": 60
+    }
+
+Simply call the hubspot client with the ``--config`` parameter:
+
+.. code-block:: bash
+
+    hubspot3 --config config.json
+
+Using ``stdin`` for parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some of the data you want to pass to the hubspot3 may be sensitive or just too much to pass it as a regular
+parameter. Therefore you can simply pass data from ``stdin`` to the client so that the data can be streamed and won't
+occur in your shell history. To do so just use the token ``__stdin__`` for one of your parameters:
+
+.. code-block:: bash
+
+    hubspot3 --config config.json \
+       contacts update --contact_id 451 \
+       --data "__stdin__" < contact_data.json
+
+In this case ``contact_data.json`` is a JSON file that contains the contacts data to update:
+
+.. code-block:: json
+
+    {
+        "properties": [
+            {
+                "property": "firstname",
+                "value": "Adrian"
+            },
+            {
+                "property": "lastname",
+                "value": "Mott"
+            }
+        ]
+    }
+
+Extending the APIs
+------------------
+
+There is one specialty in the way python-fire discovers the API clients: it will parse all classes that are derived
+from ``BaseClient`` and are provided as a property within the ``hubspot3.Hubspot3`` class. Within these API clients
+python-fire will look for public methods and provide them as a command-line operation.
+
+If you want to hide python-fire certain properties from the ``hubspot3.Hubspot3`` class (e.g. because it will instantly
+make a call to Hubspot or the property doesn't reflect an API endpoint) you can hide that property by extending the
+``Hubspot3CLIWrapper.IGNORED_PROPERTIES`` tuple within ``hubspot3/__main__.py``:
+
+.. code-block:: python
+
+    class Hubspot3CLIWrapper(object):
+
+        IGNORED_PROPERTIES = ('me', 'usage_limits', 'my_method_to_hide')
+
+In a similar fashion, public methods of the individual API clients can be hidden by extending the dictionary
+``ClientCLIWrapper.IGNORED_METHODS`` within the same module. It uses the client classes as keys and iterables
+containing method names to hide as values:
+
+.. code-block:: python
+
+    class ClientCLIWrapper(object):
+
+        IGNORED_METHODS = {
+            LeadsClient: ('camelcase_search_options',),
+            MyClient: ('my_method',),
+        }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ New to hubspot3? These may help:
 
    hubspot3/quickstart
    hubspot3/extending
+   hubspot3/command_line
 
 
 Note

--- a/hubspot3/__main__.py
+++ b/hubspot3/__main__.py
@@ -1,0 +1,238 @@
+"""Command-line interface for the Hubspot client."""
+import json
+import sys
+import types
+from functools import wraps
+from typing import Callable, Dict, List, Tuple
+
+from fire.core import Fire as fire, _Fire as fire_execute
+from fire.helputils import UsageString as build_usage_string
+from fire.parser import SeparateFlagArgs as separate_flag_args
+from hubspot3 import Hubspot3
+from hubspot3.base import BaseClient
+from hubspot3.leads import LeadsClient
+
+
+def get_config_from_file(filename):
+    """Return the content of a JSON config file as a dictionary."""
+    with open(filename, 'r', encoding='utf-8') as fp:
+        config = json.load(fp)
+    if not isinstance(config, dict):
+        raise RuntimeError('Config file content must be an object, got "{}" instead.'
+                           .format(type(config).__name__))
+    return config
+
+
+class Hubspot3CLIWrapper(object):
+    __doc__ = """
+        Hubspot3 CLI
+
+        To get a list of supported operations, call this CLI without the "--help" option.
+
+        The API client can be configured by providing options BEFORE specifying the operation to
+        execute. KWARGS are:
+        [--config CONFIG_FILE_PATH] {}
+    """.format(build_usage_string(Hubspot3).split('\n')[-1])
+
+    # Properties to ignore during discovery. The "me" property must be ignored
+    # as it would already perform an API request while being discovered and the
+    # "usage_limits" property does not contain an API.
+    # Extend this tuple if more properties that aren't API clients are added to
+    # the Hubspot3 class.
+    IGNORED_PROPERTIES = ('me', 'usage_limits')
+
+    def __init__(self, **kwargs):
+        # If no arguments were supplied at all, the desired outcome is likely
+        # the list of operations/clients. Therefore disable authentication to
+        # stop the Hubspot3 initializer from raising an exception since there
+        # is neither an API key nor an access token.
+        if not kwargs:
+            kwargs['disable_auth'] = True
+
+        # If a config file was specified, read its settings and merge the CLI
+        # options into them.
+        config_file = kwargs.pop('config', None)
+        if config_file is not None:
+            config = get_config_from_file(config_file)
+            kwargs = dict(config, **kwargs)
+
+        # Initialize the main client, discover all sub-clients and set them as
+        # attributes on this wrapper so Fire can discover them.
+        hubspot3 = Hubspot3(**kwargs)
+        self._clients = self._discover_clients(hubspot3)
+        for attr, client in self._clients.items():
+            setattr(self, attr, ClientCLIWrapper(client))
+
+    def __dir__(self):
+        return self._clients  # Let Fire only discover the client attributes.
+
+    def __str__(self):
+        return 'Hubspot3 CLI'
+
+    def _discover_clients(self, hubspot3: Hubspot3) -> Dict[str, BaseClient]:
+        """Find all client instance properties on the given Hubspot3 object."""
+        clients = {}
+        for attr in dir(hubspot3.__class__):
+            # Find properties by searching the class first - that way, a call
+            # to getattr doesn't run the properties code on the object.
+            if (attr.startswith('_') or attr in self.IGNORED_PROPERTIES or
+                    not isinstance(getattr(hubspot3.__class__, attr), property)):
+                continue
+            client = getattr(hubspot3, attr)
+            if isinstance(client, BaseClient):
+                clients[attr] = client
+        return clients
+
+
+class ClientCLIWrapper(object):
+    __doc__ = Hubspot3CLIWrapper.__doc__
+
+    # Mapping (client class to attribute names) to define methods that should
+    # be ignored during method discovery.
+    # Extend this mapping if more methods that aren't API methods are added to
+    # a client class.
+    IGNORED_METHODS = {
+        LeadsClient: ('camelcase_search_options',),
+    }
+    STDIN_TOKEN = '__stdin__'  # Argument value to trigger stdin parsing.
+
+    def __init__(self, client: BaseClient):
+        self._client_name = client.__class__.__name__
+        # Discover all API methods and set them as attributes on this wrapper
+        # so Fire can discover them.
+        self._methods = self._discover_methods(client)
+        for attr, method in self._methods.items():
+            setattr(self, attr, self._build_method_wrapper(method))
+
+    def __dir__(self):
+        return self._methods  # Let Fire only discover the API methods.
+
+    def __str__(self):
+        return 'Hubspot3 {} CLI'.format(self._client_name)
+
+    def _discover_methods(self, client: BaseClient) -> Dict[str, types.MethodType]:
+        """Find all API methods on the given client object."""
+        methods = {}
+        for attr in dir(client):
+            if attr.startswith('_') or attr in self.IGNORED_METHODS.get(client.__class__, ()):
+                continue
+            method = getattr(client, attr)
+            if isinstance(method, types.MethodType):
+                methods[attr] = method
+        return methods
+
+    def _build_method_wrapper(self, method: types.MethodType) -> Callable:
+        """Build a wrapper function around the given API method."""
+        @wraps(method)
+        def wrapper(*args, **kwargs):
+            # Replace the stdin token with the actual stdin value and call the
+            # original API method.
+            args, kwargs = self._replace_stdin_token(*args, **kwargs)
+            result = method(*args, **kwargs)
+
+            # Try to ensure to always write JSON to stdout, but don't hide any
+            # result either if it can't be JSON-encoded.
+            if isinstance(result, bytes):
+                result = result.decode('utf-8')
+            try:
+                result = json.dumps(result)
+            except Exception:
+                pass
+            print(result)
+        wrapper.__doc__ = self._build_wrapper_doc(method)
+        return wrapper
+
+    def _build_wrapper_doc(self, method: types.MethodType) -> str:
+        """Build a helpful docstring for a wrapped API method."""
+        return '\n'.join((
+            method.__doc__ or '',
+            '',
+            'Supported ARGS/KWARGS are:',
+            build_usage_string(method),
+            '',
+            'The token "{}" may be used as an argument value, which will cause JSON data to be '
+            'read from stdin and used as the actual argument value.'.format(self.STDIN_TOKEN),
+        ))
+
+    def _replace_stdin_token(self, *args, **kwargs) -> Tuple[List, Dict]:
+        """
+        Replace the values of all given arguments with the JSON-parsed value
+        from stdin if their current value is the STDIN_TOKEN.
+        """
+        stdin_indices = [index for index, value in enumerate(args) if value == self.STDIN_TOKEN]
+        stdin_keys = [key for key, value in kwargs.items() if value == self.STDIN_TOKEN]
+        if stdin_indices or stdin_keys:
+            value = json.load(sys.stdin)
+            args = list(args)
+            for index in stdin_indices:
+                args[index] = value
+            for key in stdin_keys:
+                kwargs[key] = value
+        return args, kwargs
+
+
+def split_args() -> Tuple[List, List, List]:
+    """
+    Split system args into three group of argument lists.
+
+    This method will separate all system args in client, API call and fire args
+    so that is much easier to instantiate them independently with their own
+    arguments.
+    """
+    args = sys.argv[1:]
+    if args == ['--help']:
+        # If the user only called the CLI with "--help", pass it through as an
+        # argument for Fire to invoke its help functionality.
+        return [], [], args
+
+    # Use a Fire function to split away the Fire arguments.
+    args, fire_args = separate_flag_args(args)
+
+    # Search for an argument that represents the sub-client that should be
+    # used. Since the CLI arguments have a fixed pattern (client options,
+    # sub-client name, method name, method options), this must be the first
+    # argument that isn't a named client option argument.
+    api_index = 0
+    while api_index < len(args):
+        arg = args[api_index]
+        # Named options can be passed as "--key=value" or "--key value", so the
+        # next argument to look at is either the next argument or the one after
+        # that, respectively.
+        if arg.startswith('--'):
+            if '=' not in arg:
+                api_index += 1
+            api_index += 1
+        else:
+            break
+    client_args, call_args = args[:api_index], args[api_index:]
+    return client_args, call_args, fire_args
+
+
+def main():
+    """
+    Main routine.
+
+    Split the execution up into two Fire calls: one that creates the main
+    Hubspot3CLIWrapper instance and one that works on this instance. That way,
+    the argument separator is not required and sensible details like the API
+    key are not printed out.
+    """
+    client_args, call_args, fire_args = split_args()
+
+    if fire_args:
+        # If there are arguments for an actual API method call, append the Fire
+        # arguments to that second call. Otherwise, append them to the first
+        # call as there won't be a second one.
+        (call_args or client_args).extend(['--'] + fire_args)
+    if call_args:
+        # Use the non-printing Fire routine for the first call as only the
+        # result of the second, actual API call should be printed.
+        component_trace = fire_execute(Hubspot3CLIWrapper, client_args, {}, __package__)
+        wrapper = component_trace.GetResult()
+        fire(wrapper, call_args)
+    else:
+        fire(Hubspot3CLIWrapper, client_args, __package__)
+
+
+if __name__ == '__main__':
+    main()

--- a/hubspot3/test/test_main.py
+++ b/hubspot3/test/test_main.py
@@ -1,0 +1,268 @@
+"""Tests for the Hubspot3 main module."""
+
+import io
+from contextlib import contextmanager
+from json import JSONDecodeError
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from hubspot3.__main__ import ClientCLIWrapper, Hubspot3CLIWrapper, get_config_from_file, split_args
+from hubspot3.base import BaseClient
+
+
+@contextmanager
+def does_not_raise():
+    yield
+
+
+@pytest.fixture
+def client_wrapper():
+    client = Mock(spec=BaseClient)
+    return ClientCLIWrapper(client)
+
+
+@pytest.fixture
+def cli_wrapper():
+    return Hubspot3CLIWrapper()
+
+
+@pytest.mark.parametrize('value, expectation', [
+    ('', pytest.raises(JSONDecodeError)),
+    ('[]', pytest.raises(RuntimeError)),
+    ('{}', does_not_raise()),
+    ('{"api-key": "xxxxxx-xxxxxx-xxxx-xxx"}', does_not_raise()),
+])
+def test_get_config_from_file(value, expectation):
+    with patch('hubspot3.__main__.open', mock_open(read_data=value)):
+        with expectation:
+            get_config_from_file('test.json')
+
+
+@pytest.mark.parametrize('args, expectation', [
+    (
+        ['hubspot3'],
+        (
+            [], [], []
+        )
+    ),
+    (
+        ['hubspot3', '--help'],
+        (
+            [], [], ['--help']
+        )
+    ),
+    (
+        ['hubspot3', '--', '--help'],
+        (
+            [], [], ['--help']
+        )
+    ),
+    (
+        ['hubspot3', '--timeout', '10', '--api-key', 'xxx-xxx', 'contacts'],
+        (
+            ['--timeout', '10', '--api-key', 'xxx-xxx'],
+            ['contacts'],
+            []
+        )
+    ),
+    (
+        ['hubspot3', '--api-key', 'xxx-xxx', 'contacts', 'get-all'],
+        (
+            ['--api-key', 'xxx-xxx'],
+            ['contacts', 'get-all'],
+            []
+        )
+    ),
+    (
+        ['hubspot3', 'contacts', 'get-all', '--', '--help'],
+        (
+            [],
+            ['contacts', 'get-all'],
+            ['--help']
+        )
+    ),
+    (
+        ['hubspot3', '--timeout=10', '--api-key=xxx-xxx', 'contacts'],
+        (
+            ['--timeout=10', '--api-key=xxx-xxx'],
+            ['contacts'],
+            []
+        )
+    ),
+])
+def test_split_args(args, expectation):
+    with patch('hubspot3.__main__.sys.argv', args):
+        assert split_args() == expectation
+
+
+class TestHubspot3CLIWrapper:
+
+    @pytest.mark.parametrize('kwargs, expected_kwargs, config', [
+        (
+            {},
+            {'disable_auth': True},
+            None
+        ),
+        (
+            {'config': 'config.json'},
+            {},
+            {}
+        ),
+        (
+            {'api_key': 'xxx-xxx'},
+            {'api_key': 'xxx-xxx'},
+            {}
+        ),
+        (
+            {'config': 'config.json', 'api_key': 'xxx-xxx'},
+            {'api_key': 'xxx-xxx'},
+            {'api_key': '123-456'}
+        ),
+    ])
+    @patch('hubspot3.__main__.Hubspot3CLIWrapper._discover_clients')
+    @patch('hubspot3.__main__.get_config_from_file')
+    @patch('hubspot3.__main__.Hubspot3')
+    def test_constructor(self, mock_hubspot3, mock_get_config_from_file, mock_discover_clients,
+                         kwargs, expected_kwargs, config):
+        clients = {
+            'client_a': Mock(spec=BaseClient),
+            'client_b': Mock(spec=BaseClient),
+        }
+        mock_get_config_from_file.return_value = config
+        mock_discover_clients.return_value = clients
+        wrapper = Hubspot3CLIWrapper(**kwargs)
+        assert mock_discover_clients.called
+        for name in clients.keys():
+            assert hasattr(wrapper, name)
+        mock_hubspot3.assert_called_with(**expected_kwargs)
+        if 'config' in kwargs:
+            mock_get_config_from_file.assert_called_with(kwargs['config'])
+
+    @pytest.mark.parametrize('properties, ignored_properties, expectation', [
+        (
+            {}, [], [],
+        ),
+        (
+            {'client_a': property(lambda x: Mock(spec=BaseClient))},
+            [],
+            ['client_a'],
+        ),
+        (
+            {
+                'client_a': property(lambda x: Mock(spec=BaseClient)),
+                'client_b': property(lambda x: Mock(spec=BaseClient)),
+            },
+            ['client_a'],
+            ['client_b'],
+        ),
+        (
+            {'client_a': property(lambda x: x)},
+            [],
+            [],
+        ),
+        (
+            {
+                'client_a': property(lambda x: Mock(spec=BaseClient)),
+                '_client_b': property(lambda x: Mock(spec=BaseClient)),
+                '__client_c': property(lambda x: Mock(spec=BaseClient)),
+            },
+            [],
+            ['client_a'],
+        ),
+    ])
+    def test_discover_clients(self, properties, ignored_properties, expectation, cli_wrapper):
+
+        class Hubspot3:
+            pass
+
+        for name, value in properties.items():
+            setattr(Hubspot3, name, value)
+        cli_wrapper.IGNORED_PROPERTIES = ignored_properties
+        clients = cli_wrapper._discover_clients(Hubspot3())
+        assert list(clients) == expectation
+
+
+class TestClientCLIWrapper:
+
+    @patch('hubspot3.__main__.ClientCLIWrapper._discover_methods')
+    @patch('hubspot3.__main__.ClientCLIWrapper._build_method_wrapper')
+    def test_constructor(self, mock_build_method_wrapper, mock_discover_methods):
+
+        class APIClient:
+            pass
+
+        methods = {'method_a': lambda x: x, 'method_b': lambda x: x}
+        mock_discover_methods.return_value = methods
+        mock_build_method_wrapper.return_value = 'test'
+        client = APIClient()
+        wrapper = ClientCLIWrapper(client)
+        mock_discover_methods.assert_called_with(client)
+        assert wrapper._client_name == 'APIClient'
+        assert wrapper._methods == methods
+        for fn_name, fn in methods.items():
+            assert getattr(wrapper, fn_name) == 'test'
+
+    @pytest.mark.parametrize('args, kwargs, expectation, stdin_value', [
+        ([], {}, ((), {}), None),
+        (
+            [],
+            {'data': '__stdin__'},
+            ([], {'data': '{"firstname": "Test"}'}),
+            '{"firstname": "Test"}',
+        ),
+        (['__stdin__'], {}, (['{"firstname": "Test"}'], {}), '{"firstname": "Test"}'),
+    ])
+    @patch('hubspot3.__main__.sys.stdin', Mock(new_callable=io.StringIO))
+    @patch('hubspot3.__main__.json.load')
+    def test_replace_stdin_token(self, mock_load, client_wrapper, args, kwargs, expectation,
+                                 stdin_value):
+        mock_load.return_value = stdin_value
+        value = client_wrapper._replace_stdin_token(*args, **kwargs)
+        assert value == expectation
+        if stdin_value:
+            assert mock_load.called
+
+    @pytest.mark.parametrize('methods, ignored_methods, expectation', [
+        ({}, [], []),
+        ({'a': 1337}, [], []),
+        ({'_a': 1337}, [], []),
+        ({'_method_a': lambda x: x}, [], []),
+        ({'__method_a': lambda x: x}, [], []),
+        ({'__method_a': lambda x: x, '_method_b': lambda x: x}, [], []),
+        ({'_method_a': lambda x: x, 'method_b': lambda x: x, 'c': 1337}, [], ['method_b']),
+        ({'method_a': lambda x: x, 'method_b': lambda x: x}, ['method_b'], ['method_a']),
+    ])
+    def test_discover_methods(self, client_wrapper, methods, ignored_methods, expectation):
+
+        class APIClient:
+            pass
+
+        client_wrapper.IGNORED_METHODS = {APIClient: method for method in ignored_methods}
+        for name, method in methods.items():
+            setattr(APIClient, name, method)
+        client = APIClient()
+        discovered_methods = client_wrapper._discover_methods(client)
+        assert list(discovered_methods) == expectation
+
+    @pytest.mark.parametrize('result, json_dumps, expectation', [
+        (b'{"firstname": "Name"}', Mock(side_effect=Exception), b'{"firstname": "Name"}'),
+        (b'{"firstname": "Name"}', Mock(return_value={"firstname": "Name"}), {"firstname": "Name"}),
+        ({"firstname": "Name"}, Mock(return_value={"firstname": "Name"}), {"firstname": "Name"})
+    ])
+    @patch('hubspot3.__main__.ClientCLIWrapper._replace_stdin_token')
+    @patch('hubspot3.__main__.ClientCLIWrapper._build_wrapper_doc')
+    def test_build_method_wrapper(self, mock_build_wrapper_doc, mock_replace_stdin_token,
+                                  client_wrapper, result, json_dumps, expectation):
+        def method():
+            return result
+
+        mock_replace_stdin_token.return_value = ([], {})
+        mock_build_wrapper_doc.return_value = 'Test documentation'
+        with patch('hubspot3.__main__.json.dumps', json_dumps):
+            wrapped = client_wrapper._build_method_wrapper(method)
+            wrapped()
+        assert mock_replace_stdin_token.called
+        if isinstance(result, bytes):
+            result = result.decode('utf-8')
+        json_dumps.assert_called_with(result)
+        assert wrapped.__doc__ == 'Test documentation'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+fire
 requests

--- a/setup.py
+++ b/setup.py
@@ -51,4 +51,14 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     zip_safe=False,
+    extras_require={
+        'cli': [
+            'fire==0.1.3'
+        ],
+    },
+    entry_points={
+        'console_scripts': [
+            'hubspot3=hubspot3.__main__:main'
+        ]
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{35,36,37}
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
+commands =
+    py.test --basetemp={envtmpdir}


### PR DESCRIPTION
This PR will extend the `hubspot3` package by a command line interface, which would make it possible to use all of the package's API-interacting functionality outside of a Python project. This would be useful for things like:
* embedding it in applications not written in Python
* using it to simply test API calls or to perform some quick one-time actions using the command-line

# Usage

Using a checkout of the source, it could be called like this:
`python -m hubspot3 ...`

Due to the added entrypoint in the `setup.py`, the usage becomes even easier after the package was actually installed via setuptools/pip:
`hubspot3 ...`

The actual arguments passed to the CLI would always have the following format:
`python -m hubspot3 <client args> <api name> <method name> <method args>`
where
* `<client args>` are named arguments to pass to the `Hubspot3` initializer, e.g. `--api_key demo`
* `<api name>` is the name of the "sub-client" to call, whereby the name is derived from the names are the ones of the properties on the `Hubspot3` object, e.g. `contacts`
* `<method name>` name is the name of the python method to invoke on the "sub-client", e.g. `get_contact_by_id` for the `contacts` client
* `<method args>` are arguments passed as to the called python method als parameters, e.g. simply `51` for positional arguments or `--contact_id 51` for named arguments

An example call would therefore look like this:
`python -m hubspot3 --api_key demo contacts get_contact_by_id --contact_id 51`
Assuming a contact with this ID exists, the CLI will then output the JSON-encoded results from the API on stdout.

Further descriptions and options can be found in the added sphinx documentation.

## Special options

The CLI also offers two special options:
* Using a JSON config file for the `<client args>`, so the client parameters don't have to be specified over and over again. This will also help security as credentials like the API key do not have to appear on the command line.
* Reading JSON-encoded data for a method argument from stdin, which is intended for the data that is sent to API endpoints that create/update records. This will also help with security as the data will also not appear on the command line and it helps to not exceed maximum command lengths.

More info on how to use these options can also be found in the added sphinx documentation.

# Maintenance

The CLI is designed to be low-maintenance and to not require any changes to the existing code of the API clients. It is built on [Google's Fire library](https://google.github.io/python-fire/guide/), which allows to transform objects of all kinds into CLIs. We introduced some wrapper classes for the `Hubspot3` main client and the "sub-clients" that make sure that only the right things are exposed via the Fire-generated CLI:
* The public client properties on the `Hubspot3` main client are automatically detected and transformed into CLI options.
* On these clients, all public methods are automatically detected and offered as CLI operations.

New clients should therefore automatically work as long as they are added as a property to the `Hubspot3` main class, so there will be no need to touch the CLI code when adding new clients/methods. The only time the CLI code will require some love is when properties on the `Hubspot3` main client or methods on "sub-clients" should be explicitly excluded from the CLI (the code for this is already in place).

# Requirements

The CLI requires one new python package: Google's Fire. This requirement was added to the `setup.py` as an `extra_requirement`, so it won't be installed for people who don't want to use the CLI. The package could therefore still be installed as `hubspot3` if CLI usage is not intended or as `hubspot3[cli]` if someone wants to use the CLI as well. You could also move the `fire` requirement to the regular `install_requires` if you don't think this separation of requirements is useful.

I hope this was enough of an explanation. Thank you for maintaining this library and we hope the addition of this CLI is something you consider useful, so it can become a part of `hubspot3`.