### PR TITLE
Only convert request payloads to JSON a single time

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -113,7 +113,7 @@ class BaseClient(object):
         if self.api_key:
             params["hapikey"] = params.get("hapikey") or self.api_key
 
-    def _prepare_request(self, subpath, params, data, opts, doseq=False, query=""):
+    def _prepare_request(self, subpath, params, data, opts, doseq=False, query="", retried=False):
         params = params or {}
         self._prepare_request_auth(subpath, params, data, opts)
 
@@ -138,7 +138,7 @@ class BaseClient(object):
         if self.access_token:
             headers.update({"Authorization": "Bearer {}".format(self.access_token)})
 
-        if data and headers["Content-Type"] == "application/json":
+        if data and headers["Content-Type"] == "application/json" and not retried:
             data = json.dumps(data)
 
         return url, headers, data
@@ -231,7 +231,7 @@ class BaseClient(object):
         debug = opts.get("debug")
 
         url, headers, data = self._prepare_request(
-            subpath, params, data, opts, doseq=doseq, query=query
+            subpath, params, data, opts, doseq=doseq, query=query, retried=retried,
         )
 
         if debug:


### PR DESCRIPTION
The `BaseClient._call_raw()` method currently catches `HubspotUnauthorized` errors, and then recursively calls itself after refreshing the OAuth2 tokens. This results in `BaseClient._prepare_request()` being called a second time which results in `json.dumps()` being called on the data payload twice. A payload like `{"a": 1}` then becomes `"{\"a\":1}"` and the Hubspot API can't successfully parse the content.

This PR passes the `retried` parameter into `BaseClient._prepare_request()` and skips the `json.dumps()` step for requests that are being retried.