### PR TITLE
Prevent duplicated querystring parameters when getting batches of contacts

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -114,20 +114,20 @@ class ContactsClient(BaseClient):
     def get_batch(self, ids, extra_properties: Union[list, str] = None):
         """given a batch of vids, get more of their info"""
         # default properties to fetch
-        properties = self.default_batch_properties
+        properties = set(self.default_batch_properties)
 
         # append extras if they exist
         if extra_properties:
             if isinstance(extra_properties, list):
-                properties += extra_properties
+                properties.update(extra_properties)
             if isinstance(extra_properties, str):
-                properties.append(extra_properties)
+                properties.add(extra_properties)
 
         batch = self._call(
             "contact/vids/batch",
             method="GET",
             doseq=True,
-            params={"vid": ids, "property": properties},
+            params={"vid": ids, "property": list(properties)},
         )
         # It returns a dict with IDs as keys
         return [prettify(batch[contact], id_key="vid") for contact in batch]


### PR DESCRIPTION
The `ContactsClient.get_batch()` method was mutating the `ContactsClient.default_batch_properties` when adding in the `extra_properties`. This resulted in a situation where subsequent calls to `ContactsClient.get_batch()` would cause `property=X` to be repeated once for each time it had been included previously. This eventually leads to a bad request error from Hubspot once the URI  gets too long.

This PR stops the `ContactsClient.default_batch_properties` mutation from happening, and uses a set instead of a list so that there won't be duplicate properties in the query string even if they appear in both `extra_properties` and `ContactsClient.default_batch_properties`.