### PR TITLE
added support for custom ticket properties

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -348,7 +348,7 @@ class BaseClient:
         doseq: bool = False,
         query: str = "",
         raw: bool = False,
-        properties: list() = None,
+        properties: list = None,
         **options
     ):
         result = self._call_raw(

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -110,10 +110,10 @@ class BaseClient:
             params["hapikey"] = params.get("hapikey") or self.api_key
 
     def _prepare_request(
-        self, subpath, params, data, opts, doseq=False, query="", retried=False, properties=""
+        self, subpath, params, data, opts, doseq=False, query="", retried=False, properties=[]
     ):
         params = params or {}
-        properties = properties or {}
+        properties = properties or []
         self._prepare_request_auth(subpath, params, data, opts)
 
         if opts.get("hub_id") or opts.get("portal_id"):
@@ -140,10 +140,8 @@ class BaseClient:
         if data and headers["Content-Type"] == "application/json" and not retried:
             data = json.dumps(data)
 
-        i = 0
-        while i < len(properties):
-            url = url + "&properties=" + properties[i]
-            i += 1
+        for property in properties:
+            url += '&properties={}'.format(property)
 
         return url, headers, data
 
@@ -350,7 +348,7 @@ class BaseClient:
         doseq: bool = False,
         query: str = "",
         raw: bool = False,
-        properties: str ="",
+        properties: list() = None,
         **options
     ):
         result = self._call_raw(

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -110,9 +110,10 @@ class BaseClient:
             params["hapikey"] = params.get("hapikey") or self.api_key
 
     def _prepare_request(
-        self, subpath, params, data, opts, doseq=False, query="", retried=False
+        self, subpath, params, data, opts, doseq=False, query="", retried=False, properties=""
     ):
         params = params or {}
+        properties = properties or {}
         self._prepare_request_auth(subpath, params, data, opts)
 
         if opts.get("hub_id") or opts.get("portal_id"):
@@ -138,6 +139,11 @@ class BaseClient:
 
         if data and headers["Content-Type"] == "application/json" and not retried:
             data = json.dumps(data)
+
+        i = 0
+        while i < len(properties):
+            url = url + "&properties=" + properties[i]
+            i += 1
 
         return url, headers, data
 
@@ -221,6 +227,7 @@ class BaseClient:
         doseq=False,
         query="",
         retried=False,
+        properties=None,
         **options
     ):
         opts = self.options.copy()
@@ -229,7 +236,7 @@ class BaseClient:
         debug = opts.get("debug")
 
         url, headers, data = self._prepare_request(
-            subpath, params, data, opts, doseq=doseq, query=query, retried=retried
+            subpath, params, data, opts, doseq=doseq, query=query, retried=retried, properties=properties
         )
 
         if debug:
@@ -343,6 +350,7 @@ class BaseClient:
         doseq: bool = False,
         query: str = "",
         raw: bool = False,
+        properties: str ="",
         **options
     ):
         result = self._call_raw(
@@ -353,6 +361,7 @@ class BaseClient:
             doseq=doseq,
             query=query,
             retried=False,
+            properties=properties,
             **options
         )
         return result if raw else self._digest_result(result.body)

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -234,10 +234,10 @@ class BaseClient:
         debug = opts.get("debug")
 
         url, headers, data = self._prepare_request(
-            subpath, params, data, opts, 
-            doseq=doseq, 
-            query=query, 
-            retried=retried, 
+            subpath, params, data, opts,
+            doseq=doseq,
+            query=query,
+            retried=retried,
             properties=properties
         )
 

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -110,7 +110,7 @@ class BaseClient:
             params["hapikey"] = params.get("hapikey") or self.api_key
 
     def _prepare_request(
-        self, subpath, params, data, opts, doseq=False, query="", retried=False, properties=[]
+        self, subpath, params, data, opts, doseq=False, query="", retried=False, properties=None
     ):
         params = params or {}
         properties = properties or []
@@ -140,8 +140,8 @@ class BaseClient:
         if data and headers["Content-Type"] == "application/json" and not retried:
             data = json.dumps(data)
 
-        for property in properties:
-            url += '&properties={}'.format(property)
+        for hs_property in properties:
+            url += '&properties={}'.format(hs_property)
 
         return url, headers, data
 
@@ -234,7 +234,11 @@ class BaseClient:
         debug = opts.get("debug")
 
         url, headers, data = self._prepare_request(
-            subpath, params, data, opts, doseq=doseq, query=query, retried=retried, properties=properties
+            subpath, params, data, opts, 
+            doseq=doseq, 
+            query=query, 
+            retried=retried, 
+            properties=properties
         )
 
         if debug:

--- a/hubspot3/globals.py
+++ b/hubspot3/globals.py
@@ -1,7 +1,7 @@
 """
 globals file for hubspot3
 """
-__version__ = "3.2.36"
+__version__ = "3.2.37"
 
 
 BASE_URL = "https://api.hubapi.com"

--- a/hubspot3/globals.py
+++ b/hubspot3/globals.py
@@ -1,7 +1,7 @@
 """
 globals file for hubspot3
 """
-__version__ = "3.2.37"
+__version__ = "3.2.36"
 
 
 BASE_URL = "https://api.hubapi.com"

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -47,13 +47,21 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
         )
 
-    def get(self, ticket_id: str, properties: list = None, include_deleted: bool = False, **options) -> Dict:
+    def get(self, ticket_id: str, properties: list = None, include_deleted: bool = False, **options
+    ) -> Dict:
         """
         get a ticket by its ticket_id
         TODO: add properties support
         :see: https://developers.hubspot.com/docs/methods/tickets/get_ticket_by_id
         """
-        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"]
+        properties = properties or [
+                "subject", 
+                "content", 
+                "hs_pipeline", 
+                "hs_pipeline_stage", 
+                "hs_pipeline"
+            ]
+
         params = options.pop("params", {})
         params.update({"includeDeletes": include_deleted})
         options.update({"params": params})
@@ -67,7 +75,14 @@ class TicketsClient(BaseClient):
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
         """
-        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"]
+        properties = properties or [
+                "subject", 
+                "content", 
+                "hs_pipeline", 
+                "hs_pipeline_stage", 
+                "hs_pipeline"
+            ]
+            
         finished = False
         output = []  # type: list
         offset = 0

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -47,20 +47,15 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
         )
 
-    def get(self, ticket_id: str, properties: list = None, include_deleted: bool = False, **options
+    def get(
+        self, ticket_id: str, properties: list = None, include_deleted: bool = False, **options
     ) -> Dict:
         """
         get a ticket by its ticket_id
         TODO: add properties support
         :see: https://developers.hubspot.com/docs/methods/tickets/get_ticket_by_id
         """
-        properties = properties or [
-                "subject", 
-                "content", 
-                "hs_pipeline", 
-                "hs_pipeline_stage", 
-                "hs_pipeline"
-            ]
+        properties = properties or ["subject","content","hs_pipeline","hs_pipeline_stage"]
 
         params = options.pop("params", {})
         params.update({"includeDeletes": include_deleted})
@@ -75,14 +70,8 @@ class TicketsClient(BaseClient):
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
         """
-        properties = properties or [
-                "subject", 
-                "content", 
-                "hs_pipeline", 
-                "hs_pipeline_stage", 
-                "hs_pipeline"
-            ]
-            
+        properties = properties or ["subject","content","hs_pipeline","hs_pipeline_stage"]
+
         finished = False
         output = []  # type: list
         offset = 0

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -47,7 +47,7 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
         )
 
-    def get(self, ticket_id: str, properties: list() = None, include_deleted: bool = False, **options) -> Dict:
+    def get(self, ticket_id: str, properties: list = None, include_deleted: bool = False, **options) -> Dict:
         """
         get a ticket by its ticket_id
         TODO: add properties support
@@ -62,7 +62,7 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="GET", properties=properties, **options
         )
 
-    def get_all(self, properties: list() = None, limit: int = -1, **options) -> list:
+    def get_all(self, properties: list = None, limit: int = -1, **options) -> list:
         """
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -42,7 +42,12 @@ class TicketsClient(BaseClient):
         ticket_data.append({"name": "hs_pipeline_stage", "value": stage})
         return self._call("objects/tickets", data=ticket_data, method="POST", **options)
 
-    def get(self, ticket_id: str, include_deleted: bool = False, **options) -> Dict:
+    def update(self, ticket_id: str, data: dict, **options) -> Dict:
+        return self._call(
+            "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
+        )
+
+    def get(self, ticket_id: str, properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"], include_deleted: bool = False, **options) -> Dict:
         """
         get a ticket by its ticket_id
         TODO: add properties support
@@ -54,10 +59,10 @@ class TicketsClient(BaseClient):
         options.update({"params": params})
 
         return self._call(
-            "objects/tickets/{}".format(ticket_id), method="GET", **options
+            "objects/tickets/{}".format(ticket_id), method="GET", properties=properties, **options
         )
 
-    def get_all(self, limit: int = -1, **options) -> list:
+    def get_all(self, properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"], limit: int = -1, **options) -> list:
         """
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
@@ -71,6 +76,7 @@ class TicketsClient(BaseClient):
                 "objects/tickets/paged",
                 method="GET",
                 params={"offset": offset},
+                properties=properties,
                 **options
             )
             output.extend(batch["objects"])

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -55,7 +55,7 @@ class TicketsClient(BaseClient):
         TODO: add properties support
         :see: https://developers.hubspot.com/docs/methods/tickets/get_ticket_by_id
         """
-        properties = properties or ["subject","content","hs_pipeline","hs_pipeline_stage"]
+        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage"]
 
         params = options.pop("params", {})
         params.update({"includeDeletes": include_deleted})
@@ -70,7 +70,7 @@ class TicketsClient(BaseClient):
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
         """
-        properties = properties or ["subject","content","hs_pipeline","hs_pipeline_stage"]
+        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage"]
 
         finished = False
         output = []  # type: list

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -47,13 +47,13 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
         )
 
-    def get(self, ticket_id: str, properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"], include_deleted: bool = False, **options) -> Dict:
+    def get(self, ticket_id: str, properties: list() = None, include_deleted: bool = False, **options) -> Dict:
         """
         get a ticket by its ticket_id
         TODO: add properties support
         :see: https://developers.hubspot.com/docs/methods/tickets/get_ticket_by_id
         """
-
+        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"]
         params = options.pop("params", {})
         params.update({"includeDeletes": include_deleted})
         options.update({"params": params})
@@ -62,11 +62,12 @@ class TicketsClient(BaseClient):
             "objects/tickets/{}".format(ticket_id), method="GET", properties=properties, **options
         )
 
-    def get_all(self, properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"], limit: int = -1, **options) -> list:
+    def get_all(self, properties: list() = None, limit: int = -1, **options) -> list:
         """
         Get all tickets in hubspot
         :see: https://developers.hubspot.com/docs/methods/tickets/get-all-tickets
         """
+        properties = properties or ["subject", "content", "hs_pipeline", "hs_pipeline_stage", "hs_pipeline"]
         finished = False
         output = []  # type: list
         offset = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.5
 disallow_untyped_defs = False
 ignore_missing_imports = True
 
@@ -7,8 +7,3 @@ ignore_missing_imports = True
 ignore = N802,N807,W503
 max-line-length = 100
 max-complexity = 20
-
-[egg_info]
-tag_build = 
-tag_date = 0
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 disallow_untyped_defs = False
 ignore_missing_imports = True
 
@@ -7,3 +7,8 @@ ignore_missing_imports = True
 ignore = N802,N807,W503
 max-line-length = 100
 max-complexity = 20
+
+[egg_info]
+tag_build = 
+tag_date = 0
+


### PR DESCRIPTION
While developing a ticketing system using this API, I found that support for custom ticket properties was missing.  I modified the necessary files to allow for the following:

tickets = client.tickets.get_all(properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "created_by", "hs_ticket_category", "hubspot_owner_id"])

as well as:

ticket = client.tickets.get(10239456, properties=["subject", "content", "hs_pipeline", "hs_pipeline_stage", "created_by", "hs_ticket_category", "hubspot_owner_id"])

I found it extremely valuable being able to specify custom properties.  The implementation of this feature may or may not be the proper approach, as I am new to Python. Nonetheless, I find myself having to keep merging my changes locally every time I update my hubspot3 API code.