### PR TITLE
Add fix for recently updated companies

### DIFF
--- a/hubspot3/companies.py
+++ b/hubspot3/companies.py
@@ -82,7 +82,7 @@ class CompaniesClient(BaseClient):
     def get_all(
         self,
         prettify_output: bool = True,
-        extra_properties: Union[str, List] = None,
+        extra_properties: Union[str, List]=None,
         **options
     ) -> Optional[List]:
         """get all companies, including extra properties if they are passed in"""
@@ -137,7 +137,13 @@ class CompaniesClient(BaseClient):
 
         return output
 
-    def _get_recent(self, recency_type: str, **options) -> Optional[List]:
+    def _get_recent(
+            self,
+            recency_type: str,
+            limit: int = 250,
+            offset: int = 0,
+            since: int = None,
+            **options) -> Optional[List]:
         """
         Returns either list of recently modified companies or recently created companies,
         depending on recency_type passed in. Both API endpoints take identical parameters
@@ -148,15 +154,19 @@ class CompaniesClient(BaseClient):
         """
         finished = False
         output = []
-        offset = 0
-        query_limit = 250  # Max value according to docs
 
         while not finished:
+            params = {
+                "count": query_limit,
+                "offset": offset,
+            }
+            if since:
+                params["since"] = since
             batch = self._call(
                 "companies/recent/{}".format(recency_type),
                 method="GET",
                 doseq=True,
-                params={"count": query_limit, "offset": offset},
+                params=params,
                 **options
             )
             output.extend(
@@ -171,11 +181,33 @@ class CompaniesClient(BaseClient):
 
         return output
 
-    def get_recently_modified(self, **options) -> Optional[List]:
-        return self._get_recent("modified", **options)
+    def get_recently_modified(
+            self,
+            limit: int = 250,
+            offset: int = 0,
+            since: int = None,
+            **options
+    ) -> Optional[List]:
+        return self._get_recent(
+            "modified",
+            limit=limit,
+            offset=offset,
+            since=since,
+            **options)
 
-    def get_recently_created(self, **options) -> Optional[List]:
-        return self._get_recent("created", **options)
+    def get_recently_created(
+            self,
+            limit: int = 250,
+            offset: int = 0,
+            since: int = None,
+            **options
+    ) -> Optional[List]:
+        return self._get_recent(
+            "created",
+            limit=limit,
+            offset=offset,
+            since=since,
+            **options)
 
     def get_contacts_at_a_company(self, company_id: str, **options) -> Optional[List]:
         """

--- a/hubspot3/companies.py
+++ b/hubspot3/companies.py
@@ -157,7 +157,7 @@ class CompaniesClient(BaseClient):
 
         while not finished:
             params = {
-                "count": query_limit,
+                "count": limit,
                 "offset": offset,
             }
             if since:

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -55,7 +55,8 @@ class DealsClient(BaseClient):
 
     def associate(self, deal_id, object_type, object_ids, **options):
         # Encoding the query string here since HubSpot is expecting the "id" parameter to be
-        # repeated for each object ID, which is not a standard practice and won't work otherwise.
+        # repeated for each object ID, which is not a standard practice and
+        # won't work otherwise.
         object_ids = [("id", object_id) for object_id in object_ids]
         query = urllib.parse.urlencode(object_ids)
 
@@ -69,7 +70,7 @@ class DealsClient(BaseClient):
     def get_all(
         self,
         offset: int = 0,
-        extra_properties: Union[list, str] = None,
+        extra_properties: Union[list, str]=None,
         limit: int = -1,
         **options
     ):
@@ -126,7 +127,8 @@ class DealsClient(BaseClient):
                     if not deal["isDeleted"]
                 ]
             )
-            finished = not batch["hasMore"] or (limited and len(output) >= limit)
+            finished = not batch["hasMore"] or (
+                limited and len(output) >= limit)
             offset = batch["offset"]
 
         return output if not limited else output[:limit]


### PR DESCRIPTION
The existing method for getting recent updated companies didn't provide arguments for `limit`, `offset`, and `since`, so I've added it (similar to how you already had it on deals).

See: https://developers.hubspot.com/docs/methods/companies/get_companies_modified for the API reference