### PR TITLE
Add support for custom storage of oauth2 tokens

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -31,6 +31,9 @@ from hubspot3.error import (
 class BaseClient:
     """Base abstract object for interacting with the HubSpot APIs"""
 
+    # These rules are too restrictive for the `__init__()` method and attributes.
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
+
     # Controls how long we sleep for during retries, overridden by unittests
     # so tests run faster
     sleep_multiplier = 1

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -43,10 +43,10 @@ class BaseClient:
         client_id: str = None,
         client_secret: str = None,
         oauth2_token_getter: Optional[Callable[
-            [Literal['access_token', 'refresh_token']], str,
+            [Literal['access_token', 'refresh_token'], str], str,
         ]] = None,
         oauth2_token_setter: Optional[Callable[
-            [Literal['access_token', 'refresh_token'], str], str,
+            [Literal['access_token', 'refresh_token'], str, str], None,
         ]] = None,
         timeout: int = 10,
         mixins: List = None,

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -71,6 +71,10 @@ class BaseClient:
         self.__refresh_token = refresh_token
         self.client_id = client_id
         self.client_secret = client_secret
+        if (oauth2_token_getter is None) != (oauth2_token_setter is None):
+            raise HubspotBadConfig(
+                "You must either specify both the oauth2 token setter and getter, or neither."
+            )
         self.oauth2_token_getter = oauth2_token_getter
         self.oauth2_token_setter = oauth2_token_setter
         self.log = utils.get_log("hubspot3")

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -46,10 +46,10 @@ class BaseClient:
         client_id: str = None,
         client_secret: str = None,
         oauth2_token_getter: Optional[
-            Callable[[Literal["access_token", "refresh_token"], str], str,]
+            Callable[[Literal["access_token", "refresh_token"], str], str]
         ] = None,
         oauth2_token_setter: Optional[
-            Callable[[Literal["access_token", "refresh_token"], str, str], None,]
+            Callable[[Literal["access_token", "refresh_token"], str, str], None]
         ] = None,
         timeout: int = 10,
         mixins: List = None,

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -42,12 +42,12 @@ class BaseClient:
         refresh_token: str = None,
         client_id: str = None,
         client_secret: str = None,
-        oauth2_token_getter: Optional[Callable[
-            [Literal['access_token', 'refresh_token'], str], str,
-        ]] = None,
-        oauth2_token_setter: Optional[Callable[
-            [Literal['access_token', 'refresh_token'], str, str], None,
-        ]] = None,
+        oauth2_token_getter: Optional[
+            Callable[[Literal["access_token", "refresh_token"], str], str,]
+        ] = None,
+        oauth2_token_setter: Optional[
+            Callable[[Literal["access_token", "refresh_token"], str, str], None,]
+        ] = None,
         timeout: int = 10,
         mixins: List = None,
         api_base: str = "api.hubapi.com",
@@ -110,28 +110,32 @@ class BaseClient:
     @property
     def access_token(self):
         if self.oauth2_token_getter:
-            return self.oauth2_token_getter('access_token', self.client_id) or self.__access_token
-        else:
-            return self.__access_token
+            return (
+                self.oauth2_token_getter("access_token", self.client_id)
+                or self.__access_token
+            )
+        return self.__access_token
 
     @access_token.setter
     def access_token(self, access_token):
         if self.oauth2_token_setter:
-            self.oauth2_token_setter('access_token', self.client_id, access_token)
-        else:
-            self.__access_token = access_token
+            self.oauth2_token_setter("access_token", self.client_id, access_token)
+        self.__access_token = access_token
 
     @property
     def refresh_token(self):
         if self.oauth2_token_getter:
-            return self.oauth2_token_getter('refresh_token', self.client_id) or self.__refresh_token
+            return (
+                self.oauth2_token_getter("refresh_token", self.client_id)
+                or self.__refresh_token
+            )
         else:
             return self.__refresh_token
 
     @refresh_token.setter
     def refresh_token(self, refresh_token):
         if self.oauth2_token_setter:
-            self.oauth2_token_setter('refresh_token', self.client_id, refresh_token)
+            self.oauth2_token_setter("refresh_token", self.client_id, refresh_token)
         else:
             self.__refresh_token = refresh_token
 

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -132,8 +132,7 @@ class BaseClient:
                 self.oauth2_token_getter("refresh_token", self.client_id)
                 or self.__refresh_token
             )
-        else:
-            return self.__refresh_token
+        return self.__refresh_token
 
     @refresh_token.setter
     def refresh_token(self, refresh_token):

--- a/hubspot3/test/test_lines.py
+++ b/hubspot3/test/test_lines.py
@@ -130,7 +130,10 @@ class TestLinesClient(object):
         mock_instance = mock_associations_client.return_value
         lines_client.link_line_item_to_deal(1, 1)
         mock_associations_client.assert_called_with(
-            access_token=None, api_key=None, refresh_token=None,
-            oauth2_token_getter=None, oauth2_token_setter=None,
+            access_token=None,
+            api_key=None,
+            refresh_token=None,
+            oauth2_token_getter=None,
+            oauth2_token_setter=None,
         )
         mock_instance.link_line_item_to_deal.assert_called_with(1, 1)

--- a/hubspot3/test/test_lines.py
+++ b/hubspot3/test/test_lines.py
@@ -130,6 +130,7 @@ class TestLinesClient(object):
         mock_instance = mock_associations_client.return_value
         lines_client.link_line_item_to_deal(1, 1)
         mock_associations_client.assert_called_with(
-            access_token=None, api_key=None, refresh_token=None
+            access_token=None, api_key=None, refresh_token=None,
+            oauth2_token_getter=None, oauth2_token_setter=None,
         )
         mock_instance.link_line_item_to_deal.assert_called_with(1, 1)


### PR DESCRIPTION
This implements support for using an external storage mechanism for oauth2 tokens to prevent contention issues when using multiple clients in different processes. The proposal was written out in #72, but I made some slight changes that felt natural when writing the code. This implementation replaces `BaseClient.access_token` and `BaseClient.refresh_token` with properties that defer to `BaseClient.__access_token` and `BaseClient.__refresh_token` when no external storage is configured. This behavior should be fully backwards compatible with how the library worked before this PR.

There are two new options that you can specify when initializing the base client that will change this default behavior: `oauth2_token_getter: Optional[Callable[[Literal['access_token', 'refresh_token'], str], str]] = None` and `oauth2_token_setter: Optional[Callable[[Literal['access_token', 'refresh_token'], str, str], None]] = None`. They both take the token type as the first argument and the client ID as the second argument. The setter has one additional argument that is the value of the token. These methods both default to `None`, but are used instead of deferring to `BaseClient.__access_token` and `BaseClient.__refresh_token` when the are provided. This allows using whichever shared storage mechanism you see fit to manage the tokens. If no tokens are retrieved from the getter method, then the properties will fall back to the internal variables. Even if the `access_token` is expired, this allows the client to get new tokens when the external storage is expired or otherwise unavailable.

Here's an example of how you can use the new functionality to store your oauth2 tokens in redis:

```python
import aioredis
from hubspot3 import Hubspot3


redis_client = await aioredis.create_redis_pool(url, db=db, encoding='utf-8', timeout=10)

def oauth2_token_getter(token_type: str, client_id: str) -> str:
    loop = asyncio.get_event_loop()
    key = f'hubspot-oauth2-tokens:{token_type}:{client_id}'
    return loop.run_until_complete(redis_client.get(key))

def oauth2_token_setter(token_type: str, client_id: str, token: str) -> None:
    loop = asyncio.get_event_loop()
    key = f'hubspot-oauth2-tokens:{token_type}:{client_id}'
    # Token expiration is six hours, so match that when we store the tokens.
    # See: https://developers.hubspot.com/docs/methods/oauth2/refresh-access-token
    expire_in_seconds = 6 * 60 * 60
    loop.run_until_complete(redis_client.set(key, token, expire=expire_in_seconds))

# This client will share oauth2 credentials with other clients configured in the same way.
hubspot3_client = Hubspot3(
    access_token=access_token,
    client_id=client_id,
    client_secret=client_secret,
    refresh_token=refresh_token,
    oauth2_token_getter=oauth2_token_getter,
    oauth2_token_setter=oauth2_token_setter,
)
```

Closes #72 