### PR TITLE
Update method in Tickets API now parses data dict into a list of dicts

### DIFF
--- a/hubspot3/test/test_tickets.py
+++ b/hubspot3/test/test_tickets.py
@@ -49,3 +49,17 @@ def test_get_all_tickets():
     assert tickets
     assert isinstance(tickets, list)
     assert len(tickets) > 1
+
+
+def test_update_ticket():
+    """
+    tests getting all tickets
+    :see: https://developers.hubspot.com/docs/methods/tickets/update-ticket
+    """
+    ticket = TICKETS.create("688840", "688845", properties={"subject": "test_hubspot3"})
+    ticket_update = TICKETS.update(ticket['objectId'], data={
+        'subject': 'test_hubspot3_update'
+    })
+    assert ticket_update
+    assert isinstance(ticket_update, dict)
+    assert ticket_update['properties']['subject']['value'] == 'test_hubspot3_update'

--- a/hubspot3/test/test_tickets.py
+++ b/hubspot3/test/test_tickets.py
@@ -57,9 +57,9 @@ def test_update_ticket():
     :see: https://developers.hubspot.com/docs/methods/tickets/update-ticket
     """
     ticket = TICKETS.create("688840", "688845", properties={"subject": "test_hubspot3"})
-    ticket_update = TICKETS.update(ticket['objectId'], data={
-        'subject': 'test_hubspot3_update'
-    })
+    ticket_update = TICKETS.update(
+        ticket["objectId"], data={"subject": "test_hubspot3_update"}
+    )
     assert ticket_update
     assert isinstance(ticket_update, dict)
-    assert ticket_update['properties']['subject']['value'] == 'test_hubspot3_update'
+    assert ticket_update["properties"]["subject"]["value"] == "test_hubspot3_update"

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -49,7 +49,10 @@ class TicketsClient(BaseClient):
         """
         ticket_data = [{"name": x, "value": y} for x, y in data.items()]
         return self._call(
-            "objects/tickets/{}".format(ticket_id), method="PUT", data=ticket_data, **options
+            "objects/tickets/{}".format(ticket_id),
+            method="PUT",
+            data=ticket_data,
+            **options
         )
 
     def get(

--- a/hubspot3/tickets.py
+++ b/hubspot3/tickets.py
@@ -47,8 +47,9 @@ class TicketsClient(BaseClient):
         update a ticket by its ticket id, with the given data
         :see: https://developers.hubspot.com/docs/methods/tickets/update-ticket
         """
+        ticket_data = [{"name": x, "value": y} for x, y in data.items()]
         return self._call(
-            "objects/tickets/{}".format(ticket_id), method="PUT", data=data, **options
+            "objects/tickets/{}".format(ticket_id), method="PUT", data=ticket_data, **options
         )
 
     def get(


### PR DESCRIPTION
Update method in Tickets API didn't parse dict therefore the user needed to send a list of dicts, now it parses the dict. Also added tests for update ticket method.

related comment in TicketAPI issue: https://github.com/jpetrucciani/hubspot3/issues/29#issuecomment-569056536
@vivithemage can you please also take a look 👼 