### PR TITLE
Remove overriding default bool evaluation of exceptions

### DIFF
--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -19,9 +19,6 @@ class EmptyResult:
         self.msg = ""
         self.reason = ""
 
-    def __bool__(self):
-        return False
-
 
 class HubspotError(ValueError):
     """Any problems get thrown as HubspotError exceptions with the relevant info inside"""
@@ -57,9 +54,6 @@ class HubspotError(ValueError):
     def __contains__(self, item):
         """tests if the given item text is in the error text"""
         return item in self.__str__()
-
-    def __bool__(self):
-        return False
 
     def __init__(self, result, request, err=None):
         super(HubspotError, self).__init__(result and result.reason or "Unknown Reason")


### PR DESCRIPTION
Raising this pull request as I'm not sure if there is a reason behind Hubspot exceptions being evaluated as `False`, more of a question but if there's no reason it'd be great to have the exceptions follow the inbuilt exception evaluation.