### PR TITLE
Fix type hints of companies.search_domain

### DIFF
--- a/hubspot3/companies.py
+++ b/hubspot3/companies.py
@@ -53,7 +53,7 @@ class CompaniesClient(BaseClient):
         return self._call("companies/{}".format(company_id), method="GET", **options)
 
     def search_domain(
-        self, domain: str, limit: int = 1, extra_properties: Dict = None, **options
+        self, domain: str, limit: int = 1, extra_properties: Union[List, str, None] = None, **options
     ) -> Dict:
         """searches for companies by domain name. limit is max'd at 100"""
         # default properties to fetch
@@ -69,8 +69,10 @@ class CompaniesClient(BaseClient):
         if extra_properties:
             if isinstance(extra_properties, list):
                 properties += extra_properties
-            if isinstance(extra_properties, str):
+            elif isinstance(extra_properties, str):
                 properties.append(extra_properties)
+            else:
+                raise TypeError("extra_properties must be a list or str if provided")
 
         return self._call(
             "domains/{}/companies".format(domain),


### PR DESCRIPTION
extra_properties accepts a list or str, but the type hint said Dict and was not optional

I did not find a unit test for the company code that I could update.