### PR TITLE
add __reduce__ to HubspotError so it can survive pickling

### DIFF
--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -68,6 +68,9 @@ class HubspotError(ValueError):
         self.request = request
         self.err = err
 
+    def __reduce__(self):
+        return (self.__class__, (self.result, self.request))
+
     def __str__(self):
         params = {}
         request_keys = ("method", "host", "url", "data", "headers", "timeout", "body")


### PR DESCRIPTION
I was capturing the result of a delete call where HubspotNotFound was being thrown and I found I could not unpickle it.  I had to add a __reduce__ to HubspotError in order for it to work.