### PR TITLE
Add a Users API client

### DIFF
--- a/hubspot3/__init__.py
+++ b/hubspot3/__init__.py
@@ -355,6 +355,13 @@ class Hubspot3:
         return TicketsClient(**self.auth, **self.options)
 
     @property
+    def users(self):
+        """returns a hubspot3 users client"""
+        from hubspot3.users import UsersClient
+
+        return UsersClient(**self.auth, **self.options)
+
+    @property
     def workflows(self):
         """returns a hubspot3 workflows client"""
         from hubspot3.workflows import WorkflowsClient

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -50,3 +50,14 @@ class UsersClient(BaseClient):
     def get_roles(self, **options):
         """Get all existing user roles."""
         return self._call("roles", method="GET", **options)
+
+    def update_by_email(self, email: str, role_id: Union[int, str], **options):
+        """Update the user with the specified email address."""
+        data = {"roleId": str(role_id)}
+        params = {"idProperty": "EMAIL"}
+        return self._call(email, data=data, method="PUT", params=params, **options)
+
+    def update_by_id(self, user_id: Union[int, str], role_id: Union[int, str], **options):
+        """Update the user with the specified user ID."""
+        data = {"roleId": str(role_id)}
+        return self._call(str(user_id), data=data, method="PUT", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -47,6 +47,11 @@ class UsersClient(BaseClient):
         """Delete the user with the specified user ID."""
         return self._call(str(user_id), method="DELETE", **options)
 
+    def get_by_email(self, email: str, **options):
+        """Get user with the specified email address."""
+        params = {"idProperty": "EMAIL"}
+        return self._call(email, params=params, method="GET", **options)
+
     def get_by_id(self, user_id: Union[int, str], **options):
         """Get user with the specified user ID."""
         return self._call(str(user_id), method="GET", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -10,6 +10,7 @@ USERS_API_VERSION = "v3"
 # Pylint erroneously thinks that `Union` is unsubscriptable.
 # pylint: disable=unsubscriptable-object
 
+
 class UsersClient(BaseClient):
     """
     hubspot3 Users client
@@ -21,7 +22,11 @@ class UsersClient(BaseClient):
         return "settings/{}/users/{}".format(USERS_API_VERSION, subpath)
 
     def create(
-        self, email: str, role_id: Union[int, str], send_welcome_email: bool = False, **options
+        self,
+        email: str,
+        role_id: Union[int, str],
+        send_welcome_email: bool = False,
+        **options
     ):
         """Create a new user with minimal contacts-base permissions."""
         data = {
@@ -59,7 +64,9 @@ class UsersClient(BaseClient):
         params = {"idProperty": "EMAIL"}
         return self._call(email, data=data, method="PUT", params=params, **options)
 
-    def update_by_id(self, user_id: Union[int, str], role_id: Union[int, str], **options):
+    def update_by_id(
+        self, user_id: Union[int, str], role_id: Union[int, str], **options
+    ):
         """Update the user with the specified user ID."""
         data = {"roleId": str(role_id)}
         return self._call(str(user_id), data=data, method="PUT", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -34,6 +34,15 @@ class UsersClient(BaseClient):
             **options,
         )
 
+    def delete_by_email(self, email: str, **options):
+        """Delete the user with the specified email address."""
+        params = {"idProperty": "EMAIL"}
+        return self._call(email, params=params, method="DELETE", **options)
+
+    def delete_by_id(self, user_id: Union[int, str], **options):
+        """Delete the user with the specified ID."""
+        return self._call(str(user_id), method="DELETE", **options)
+
     def get_by_id(self, user_id: Union[int, str], **options):
         """Get user specified by ID."""
         return self._call(str(user_id), method="GET", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -18,6 +18,22 @@ class UsersClient(BaseClient):
         """Get the full api url for the given subpath on this client."""
         return "settings/{}/users/{}".format(USERS_API_VERSION, subpath)
 
+    def create(
+        self, email: str, role_id: Union[int, str], send_welcome_email: bool = False, **options
+    ):
+        """Create a new user with minimal contacts-base permissions."""
+        data = {
+            "email": email,
+            "roleId": str(role_id),
+            "sendWelcomeEmail": send_welcome_email,
+        }
+        return self._call(
+            "",
+            data=data,
+            method="POST",
+            **options,
+        )
+
     def get_by_id(self, user_id: Union[int, str], **options):
         """Get user specified by ID."""
         return self._call(str(user_id), method="GET", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -40,11 +40,11 @@ class UsersClient(BaseClient):
         return self._call(email, params=params, method="DELETE", **options)
 
     def delete_by_id(self, user_id: Union[int, str], **options):
-        """Delete the user with the specified ID."""
+        """Delete the user with the specified user ID."""
         return self._call(str(user_id), method="DELETE", **options)
 
     def get_by_id(self, user_id: Union[int, str], **options):
-        """Get user specified by ID."""
+        """Get user with the specified user ID."""
         return self._call(str(user_id), method="GET", **options)
 
     def get_roles(self, **options):

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -1,0 +1,21 @@
+"""
+hubspot users api
+"""
+from hubspot3.base import BaseClient
+
+USERS_API_VERSION = "v3"
+
+
+class UsersClient(BaseClient):
+    """
+    hubspot3 Users client
+    :see: https://developers.hubspot.com/docs/api/settings/user-provisioning
+    """
+
+    def _get_path(self, subpath: str):
+        """Get the full api url for the given subpath on this client."""
+        return "settings/{}/users/{}".format(USERS_API_VERSION, subpath)
+
+    def get_roles(self, **options):
+        """Get all existing user roles."""
+        return self._call("roles", method="GET", **options)

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -1,6 +1,8 @@
 """
 hubspot users api
 """
+from typing import Union
+
 from hubspot3.base import BaseClient
 
 USERS_API_VERSION = "v3"
@@ -15,6 +17,10 @@ class UsersClient(BaseClient):
     def _get_path(self, subpath: str):
         """Get the full api url for the given subpath on this client."""
         return "settings/{}/users/{}".format(USERS_API_VERSION, subpath)
+
+    def get_by_id(self, user_id: Union[int, str], **options):
+        """Get user specified by ID."""
+        return self._call(str(user_id), method="GET", **options)
 
     def get_roles(self, **options):
         """Get all existing user roles."""

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -7,6 +7,8 @@ from hubspot3.base import BaseClient
 
 USERS_API_VERSION = "v3"
 
+# Pylint erroneously thinks that `Union` is unsubscriptable.
+# pylint: disable=unsubscriptable-object
 
 class UsersClient(BaseClient):
     """

--- a/hubspot3/users.py
+++ b/hubspot3/users.py
@@ -7,9 +7,6 @@ from hubspot3.base import BaseClient
 
 USERS_API_VERSION = "v3"
 
-# Pylint erroneously thinks that `Union` is unsubscriptable.
-# pylint: disable=unsubscriptable-object
-
 
 class UsersClient(BaseClient):
     """


### PR DESCRIPTION
Hubspot recently added a [Users API](https://developers.hubspot.com/docs/api/settings/user-provisioning) for managing user accounts. This pull request adds a new `UsersClient` class that adds support for each of the available API methods. This API notably requires OAuth permission scopes, and requests will fail without them. The returned errors are fairly clear about the issue when that happens. For example, here's the error when changing a user role requires access to the billing scope:

```
HubspotBadRequest:                                                                                                     
Error validating request.                                                                                              
                                                                                                                                                                                                                                               
---- request ----                                                                                                                                                                                                                              
PUT api.hubapi.com/settings/v3/users/example@example.com?idProperty=EMAIL, [timeout=<class 'int'>]             
                                                                                                                                                                                                                                               
---- body ----                                                                                                                                                                                                                                 
<class 'NoneType'>                                                                                                                                                                                                                             
                                                                                                                       
---- headers ----                                                                                                      
<class 'dict'>                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                               
---- result ----                                                                                                                                                                                                                               
<class 'int'>                                                                                                          
                                                                                                                       
---- body -----                                                                                                        
{"status":"error","message":"Error validating request.","correlationId":"848ea612-ba12-4f6d-aab6-4476d827089b","errors":[{"message":"App must have the billing-write scope to modify roles for paid seats."},{"message":"This role is unavailable and can't be assigned to a user. This can happen when an account upgrades or downgrades their plan."}],"category":"VALIDATION_ERROR"}
                                                                                                                                                                                                                                               
---- headers -----                                                                                                                                                                                                                             
<class 'http.client.HTTPMessage'>                                                                                      
                                                                                                                       
---- reason ----                                                                                                       
Bad Request                                                                                                                                                                                                                                    
                                                                                                                       
---- trigger error ----                                                                                                
<class 'NoneType'> 
```

-----

The prospector CI check is failing because pylint is erroneously identifying various types from the `typing` module as unsubscriptable. This isn't unique to the new `users` submodule, the same thing is happening with the unchanged `companies`, `contacts`, `crm_associations`, `deals`, `lines`, `properties`, and `utils` submodules.