### PR TITLE
fix: remove sensitive data from the logs

### DIFF
--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -13,7 +13,7 @@ import zlib
 from typing import Callable, List, Optional, Union
 from typing_extensions import Literal
 from hubspot3 import utils
-from hubspot3.utils import force_utf8
+from hubspot3.utils import force_utf8, uglify_hapikey
 from hubspot3.error import (
     HubspotBadConfig,
     HubspotBadRequest,
@@ -391,14 +391,18 @@ class BaseClient:
                 raise
             except HubspotError as exception:
                 if try_count > num_retries:
-                    logging.warning("Too many retries for {}".format(url))
+                    logging.warning(
+                        "Too many retries for {}".format(uglify_hapikey(url))
+                    )
                     raise
                 # Don't retry errors from 300 to 499
                 if exception.result and 300 <= exception.result.status < 500:
                     raise
                 self._prepare_request_retry(method, url, headers, data)
                 self.log.warning(
-                    "HubspotError {} calling {}, retrying".format(exception, url)
+                    "HubspotError {} calling {}, retrying".format(
+                        exception, uglify_hapikey(url)
+                    )
                 )
             # exponential back off
             # wait 0 seconds, 1 second, 3 seconds, 7 seconds, 15 seconds, etc

--- a/hubspot3/error.py
+++ b/hubspot3/error.py
@@ -2,9 +2,8 @@
 hubspot3 error helpers
 """
 import json
-from urllib import parse
 
-from hubspot3.utils import force_utf8
+from hubspot3.utils import force_utf8, uglify_hapikey
 
 
 class EmptyResult:
@@ -64,7 +63,7 @@ class HubspotError(ValueError):
         if request is None:
             request = {}
         if "url" in request:
-            request["url"] = self._uglify_hapikey(request["url"])
+            request["url"] = uglify_hapikey(request["url"])
         self.request = request
         self.err = err
 
@@ -100,22 +99,6 @@ class HubspotError(ValueError):
             else:
                 unicode_data[key] = str(type(val))
         return unicode_data
-
-    def _uglify_hapikey(self, url):
-        url_parse = parse.urlparse(url)
-        parse_query = parse.parse_qs(url_parse.query)
-        if "hapikey" not in parse_query:
-            return url
-        parse_query["hapikey"][0] = "{}****".format(parse_query["hapikey"][0][0:4])
-        parse_result = parse.ParseResult(
-            scheme=url_parse.scheme,
-            netloc=url_parse.netloc,
-            path=url_parse.path,
-            params=url_parse.params,
-            query=parse.urlencode(parse_query, doseq=True, safe="*"),
-            fragment=url_parse.fragment,
-        )
-        return parse.urlunparse(parse_result)
 
 
 class HubspotBadConfig(Exception):

--- a/hubspot3/utils.py
+++ b/hubspot3/utils.py
@@ -4,6 +4,7 @@ base utils for the hubspot3 library
 import logging
 import sys
 from collections import OrderedDict
+from urllib import parse
 from typing import Dict, Union
 
 
@@ -48,6 +49,26 @@ def prettify(obj_with_props, id_key):
         pass
 
     return prettified
+
+
+def uglify_hapikey(url: str) -> str:
+    """
+    Uglifies the API key on a HubSpot URL
+    """
+    url_parse = parse.urlparse(url)
+    parse_query = parse.parse_qs(url_parse.query)
+    if "hapikey" not in parse_query:
+        return url
+    parse_query["hapikey"][0] = "{}****".format(parse_query["hapikey"][0][0:4])
+    parse_result = parse.ParseResult(
+        scheme=url_parse.scheme,
+        netloc=url_parse.netloc,
+        path=url_parse.path,
+        params=url_parse.params,
+        query=parse.urlencode(parse_query, doseq=True, safe="*"),
+        fragment=url_parse.fragment,
+    )
+    return parse.urlunparse(parse_result)
 
 
 def ordered_dict(dictionary: Dict) -> Union[Dict, OrderedDict]:


### PR DESCRIPTION
Hi @jpetrucciani 

When an error occurs on HubSpot, the retry procedure will log the entire URL for the request, this URL includes the API key.

This simple PR, reuses the `uglify_hapikey` from `HubspotError` making it an utility function (makes no use of any class data)
 