### PR TITLE
typing_extensions is only needed for Python versions below 3.8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ html_theme = "default"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -11,6 +11,7 @@ import urllib.parse
 import urllib.error
 import zlib
 from typing import Callable, List, Optional, Union
+
 try:
     from typing import Literal
 except ImportError:

--- a/hubspot3/base.py
+++ b/hubspot3/base.py
@@ -11,7 +11,10 @@ import urllib.parse
 import urllib.error
 import zlib
 from typing import Callable, List, Optional, Union
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 from hubspot3 import utils
 from hubspot3.utils import force_utf8
 from hubspot3.error import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fire==0.1.3
-typing_extensions==3.7.4.1
+typing_extensions==3.7.4.1; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     download_url="https://github.com/jpetrucciani/hubspot3.git",
     license="LICENSE",
     packages=["hubspot3"],
-    install_requires=["typing_extensions"],
+    install_requires=["typing_extensions; python_version < '3.8'"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
`typing.Literal` is built-in to the `typing` module starting in Python 3.8. As a result, we don't need to depend on `typing_extensions` for Python 3.8 and above.